### PR TITLE
Use markdown-toc instead of marked-toc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ var engine = require('bloggy')();
 engine.extendWith(require('bloggy-marked-toc'));
 ```
 
-After the content of a blog entry is loaded by the engine, it has a property `toc`, which contains the table of contents as an object. The structure of this object is documented [here](https://github.com/jonschlinkert/marked-toc#tocraw).
+After the content of a blog entry is loaded by the engine, it has a property `toc`, which contains the table of contents.
 
 License
 -------

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var toc = require('marked-toc');
+var toc = require('markdown-toc');
 
 exports.init = function (engine) {
     var original = engine.loadContent;
 
     engine.loadContent = function (entry, content, callback) {
         original(entry, content, function (transformedContent) {
-            entry.toc = toc.raw(content);
+            entry.toc = toc(content).content;
 
             callback(transformedContent);
         });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "marked-toc": "^0.2.5"
+    "markdown-toc": "^1.1.0"
   },
   "keywords": [
     "blog",
@@ -20,7 +20,7 @@
     "lightweight",
     "marked"
   ],
-  "repository": "git://github.com/marcells/bloggy-summary",
+  "repository": "git://github.com/marcells/bloggy-marked-toc",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
This PR follows [this issue](https://github.com/marcells/bloggy-summary/issues/1) (yeah I created this issue on the wrong repo).

This fixes :
* the module `marked-toc` being deprecated, now uses `markdown-toc`
* the GitHub link in the README not pointing to the proper repo

As **the 2 modules have different outputs**, this PR is a breaking change (see the new README).
If this PR gets merged, **I recommend bumping the module's major version (to 1.0.0)**, otherwise it could break some people's code.